### PR TITLE
Do not strip whitespace from whitespace-only lines

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,10 +32,11 @@ define(function (require, exports, module) {
             var linesToTrim = [];
             var rawLines = text.split("\n");
             var hasWhitespace = /\s+$/;
+            var isOnlyWhitespace = /^\s+$/
 
             // go through all the lines and add the indices of the lines with whitespace (ignoring the line the cursor is on)
             for (var i = 0; i < rawLines.length; i++) {
-                if (cursorPos.line !== i && hasWhitespace.test(rawLines[i])) linesToTrim.push(i);
+                if (cursorPos.line !== i && hasWhitespace.test(rawLines[i]) && !isOnlyWhitespace.test(rawLines[i])) linesToTrim.push(i);
             }
 
             doc.batchOperation(function() {


### PR DESCRIPTION
When using the indent guides extension, the indents get interrupted if whitespace-only lines get stripped of their whitespace. It looks really disturbing and this fixes that issue. 

![screen shot 2014-10-30 at 19 41 24](https://cloud.githubusercontent.com/assets/7327050/4849808/6755041c-6064-11e4-9da1-0d22c725c4fc.png)
